### PR TITLE
Fix IP leak when moving a thread and leaving a shadow message

### DIFF
--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -1912,7 +1912,8 @@ function mod_move($originBoard, $postID) {
 				'has_file' => false,
 				// attach to original thread
 				'thread' => $postID,
-				'op' => false
+				'op' => false,
+				'ip' => get_ip_hash($_SERVER['REMOTE_ADDR'])
 			);
 
 			$spost['body'] = $spost['body_nomarkup'] =  sprintf($config['mod']['shadow_mesage'], '>>>/' . $targetBoard . '/' . $newID);


### PR DESCRIPTION
When leaving a shadow message with bcrypt on, the real ip address would leak. This PR will prevent this by getting the value from `get_ip_hash`. If its not hashed, it will return the original ip, otherwise, it will return the hashed version.