### PR TITLE
Fixes faulty regex in validate_ip_string function

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -3833,7 +3833,7 @@ function validate_ip_string($ip)
 	if (!$config['bcrypt_ip_addresses'] && filter_var($ip, FILTER_VALIDATE_IP) === false)
 		return false;
 	// else if ($config['bcrypt_ip_addresses'] && !ctype_alnum($ip) && strlen($ip) != 53)
-	else if ($config['bcrypt_ip_addresses'] && preg_match("/[._0-9A-Za-z]{31}/", $ip) != 1)
+	else if ($config['bcrypt_ip_addresses'] && preg_match("/\b[._0-9A-Za-z]{31}\b/", $ip) != 1)
 		return false;
 	
 	return true;

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -3833,7 +3833,7 @@ function validate_ip_string($ip)
 	if (!$config['bcrypt_ip_addresses'] && filter_var($ip, FILTER_VALIDATE_IP) === false)
 		return false;
 	// else if ($config['bcrypt_ip_addresses'] && !ctype_alnum($ip) && strlen($ip) != 53)
-	else if ($config['bcrypt_ip_addresses'] && preg_match("/\b[._0-9A-Za-z]{31}\b/", $ip) != 1)
+	else if ($config['bcrypt_ip_addresses'] && preg_match("/^[._0-9A-Za-z]{31}$/", $ip) != 1)
 		return false;
 	
 	return true;


### PR DESCRIPTION
The current implementation only works when an ip is less than 31 characters, if the ip exceed 31 characters, the function returns true

Test code: 

```php
$ip[] = 'FRwJzgDIOhfekjtPqFzobWAyZ2Z3Dma'; // valid ip (31 chars). function returns true
$ip[] = 'FRwJzgDIOhfekjdddtPqFzobWAyZ2Z3Dma'; // invalid ip (34 chars). function returns true
$ip[] = 'FRwJzgDIOhfekPqFzobWAyZ2Z3Dma'; // invalid ip (29 chars). function returns false 
foreach($ip as $i)
	var_dump(validate_ip_string($i));


```
